### PR TITLE
Add `module` entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "vue-functional-data-merge",
   "version": "2.0.2",
   "description": "Vue.js util for intelligently merging data passed to functional components.",
-  "main": "dist/lib.esm.js",
+	"main": "dist/lib.common.js",
+	"module": "dist/lib.esm.js",
   "scripts": {
     "rollup": "rollup -c",
     "prebuild": "scripts/clean.js",


### PR DESCRIPTION
Add `module` entry to package.json, and use `lib.common.js` as main entry.

> If your `package.json` file also has a `module` field, ES6-aware tools like Rollup and webpack 2 will import the ES6 module version directly.

https://rollupjs.org/#compatibility

https://stackoverflow.com/questions/42708484/what-is-the-module-package-json-field-for