### PR TITLE
Update codebase to vue 3

### DIFF
--- a/__test__/__snapshots__/handler-merge.test.ts.snap
+++ b/__test__/__snapshots__/handler-merge.test.ts.snap
@@ -2,13 +2,11 @@
 
 exports[`should call the right-most argument first: merge-4 1`] = `
 Object {
-  "on": Object {
-    "click": Array [
-      [Function],
-      [Function],
-      [Function],
-      [Function],
-    ],
-  },
+  "onClick": Array [
+    [Function],
+    [Function],
+    [Function],
+    [Function],
+  ],
 }
 `;

--- a/__test__/array-merge.test.ts
+++ b/__test__/array-merge.test.ts
@@ -14,7 +14,8 @@ it("should convert style strings to objects", () => {
       style: `
       background: url("https://unsplash.com/photos/xSPd2ifk5L8");
       background-image: url(https://foo.com/bar?baz;biz;);
-      background-position: center center`,
+      background-position: center center
+      content: "Hello!"`,
     },
     {
       style:
@@ -54,7 +55,7 @@ it("should execute array merge on class, style, directive properties", () => {
 
   let actual = mergeData(vd1, vd2);
   let expected = {
-    class: ["d", "a", { e: true, f: false, b: true, c: false }],
+    class: ["a", "d", { e: true, f: false, b: true, c: false }],
     style: [
       { position: "absolute" },
       { display: "block" },

--- a/__test__/array-merge.test.ts
+++ b/__test__/array-merge.test.ts
@@ -14,8 +14,7 @@ it("should convert style strings to objects", () => {
       style: `
       background: url("https://unsplash.com/photos/xSPd2ifk5L8");
       background-image: url(https://foo.com/bar?baz;biz;);
-      background-position: center center
-      content: "Hello!"`,
+      background-position: center center`
     },
     {
       style:

--- a/__test__/array-merge.test.ts
+++ b/__test__/array-merge.test.ts
@@ -1,8 +1,7 @@
-import { VNodeData } from "vue";
 import { mergeData } from "../src/index";
 
 it("should convert style strings to objects", () => {
-  let data: VNodeData[] = [
+  let data: Record<string, unknown>[] = [
     {
       style: " transform : translateX(-50%) ; ",
     },
@@ -44,18 +43,18 @@ it("should convert style strings to objects", () => {
 });
 
 it("should execute array merge on class, style, directive properties", () => {
-  let vd1: VNodeData = {
+  let vd1: Record<string, unknown> = {
     class: ["a", { b: true, c: false }],
     style: ["display:block;", { color: "red", fontSize: "16px" }],
   };
-  let vd2: VNodeData = {
+  let vd2: Record<string, unknown> = {
     class: ["d", { e: true, f: false }],
     style: "position:absolute;",
   };
 
   let actual = mergeData(vd1, vd2);
   let expected = {
-    class: ["d", { e: true, f: false }, "a", { b: true, c: false }],
+    class: ["d", "a", { e: true, f: false, b: true, c: false }],
     style: [
       { position: "absolute" },
       { display: "block" },
@@ -69,18 +68,6 @@ it("should execute array merge on class, style, directive properties", () => {
   expect(actual).not.toBe(expected);
   // Check that level 1 object refs do not match
   expect(actual.class).not.toBe(vd1.class);
-  expect(actual.class).not.toBe(vd2.class);
   expect(actual.style).not.toBe(vd1.style);
   expect(actual.style).not.toBe(vd2.style);
-});
-
-it("should init types to array", () => {
-  let test = mergeData({ class: "string" });
-  expect(Array.isArray(test.class)).toBe(true);
-
-  test = mergeData({ class: { string: true } });
-  expect(Array.isArray(test.class)).toBe(true);
-
-  test = mergeData({ class: ["string"] });
-  expect(Array.isArray(test.class)).toBe(true);
 });

--- a/__test__/class-merge.test.ts
+++ b/__test__/class-merge.test.ts
@@ -1,0 +1,148 @@
+import { mergeData } from "../src/index";
+
+it("should find and merge class objects in arrays", () => {
+  let data: Record<string, unknown>[] = [
+    {
+      class: "btn",
+    },
+    {
+      class: ["test", {test2: true, test3: false}],
+    },
+    {
+      class: {
+        toggle: true,
+        warning: false
+      }
+    },
+    {
+      class: ["container-child"],
+    },
+  ];
+
+  let expected = {
+    class: [
+      "btn",
+      "container-child",
+      "test",
+      {
+        toggle: true,
+        warning: false,
+        test2: true,
+        test3: false
+      },
+    ],
+  };
+
+  expect(mergeData(...data).class).toEqual(expect.arrayContaining(expected.class as any[]));
+});
+
+it("should append a class object if the target is an array with only strings", () => {
+  const data: Record<string, unknown>[] = [
+    {
+      class: ["btn", "container-child"],
+    },
+    {
+      class: {
+        toggle: true,
+        warning: false
+      }
+    },
+  ];
+
+  const data2: Record<string, unknown>[] = [
+    {
+      class: ["btn", "container-child"],
+    },
+    {
+      class: [{
+        toggle: true,
+        warning: false
+      }]
+    },
+  ];
+
+  const expected = {
+    class: ["btn", "container-child", {toggle: true, warning: false}]
+  };
+
+  const actual = mergeData(...data);
+  const actual2 = mergeData(...data2);
+
+  expect(actual).toEqual(expected);
+  expect(actual2).toEqual(expected)
+});
+
+it("Should avoid merging duplicate classes", () => {
+  const data = [
+    {
+      class: ["test", "test2", "test3", "test4"],
+    },
+    {
+      class: ["test2", "test5", "test0", "test", "test4"]
+    }
+  ]
+
+  const expected = {
+    class: ["test", "test2", "test3", "test4", "test5", "test0"]
+  }
+
+  const actual = mergeData(...data);
+  expect(actual).toEqual(expected);
+});
+
+it("should handle undefined class values", () => {
+  const data = [
+    {
+      class: undefined,
+    },
+    {
+      class: 'test'
+    }
+  ]
+
+  const expected = {
+    class: 'test',
+  }
+
+  const actual = mergeData(...data);
+  expect(actual).toEqual(expected)
+})
+
+it("should overwrite class object properties on merging class objects", () => {
+  const data = [
+    {
+      class: {test1: true, test2: false}
+    },
+    {
+      class: {test1: false, test4: true}
+    }
+  ]
+
+  const expected = {
+    class: {test1: false, test2: false, test4: true}
+  }
+
+  const actual = mergeData(...data);
+  expect(actual).toEqual(expected);
+})
+
+it("Should deconstruct arrays back to an object if the result is an array with only one object", () => {
+  const data = [
+    {
+      class: [{test1: true, test2: false}]
+    },
+    {
+      class: [{test2: true, test3: false, test4: true}],
+    },
+    {
+      class: [{test1: false, test2: false, test4: true}]
+    },
+  ]
+
+  const expected = {
+    class: {test1: false, test2: false, test3: false, test4: true}
+  }
+
+  const actual = mergeData(...data);
+  expect(actual).toEqual(expected);
+})

--- a/__test__/handler-merge.test.ts
+++ b/__test__/handler-merge.test.ts
@@ -1,54 +1,50 @@
-import { VNodeData } from "vue";
 import { mergeData } from "../src/index";
 
 it("should not mutate original object (issue #2)", () => {
-  let def1 = { on: { click() {} } };
-  let def2 = { on: { click() {} } };
+  let def1 = { onClick() {} };
+  let def2 = { onClick() {} };
 
-  let onclick1 = def1.on.click;
-  let onclick2 = def2.on.click;
+  let onclick1 = def1.onClick;
+  let onclick2 = def2.onClick;
 
   let data = mergeData({}, def1, def2);
 
-  expect(def1.on).not.toBe(data.on);
-  expect(def2.on).not.toBe(data.on);
+  expect(def1.onClick).toBe(onclick1);
+  expect(def2.onClick).toBe(onclick2);
 
-  expect(def1.on.click).toBe(onclick1);
-  expect(def2.on.click).toBe(onclick2);
-
-  expect(data.on.click).toContain(onclick1);
-  expect(data.on.click).toContain(onclick2);
+  expect(data.onClick).toContain(onclick1);
+  expect(data.onClick).toContain(onclick2);
 });
 
 it("should set single handlers and concat multi", () => {
   let h1 = console.log;
   let h2 = console.info;
   let h3 = console.error;
-  let actual: VNodeData;
+  let actual: Record<string, unknown>;
 
   actual = mergeData(
     { class: ["btn", "text-center"] },
-    { on: { mouseup: h1 } }
+    { onMouseup: h1 }
   );
-  expect(actual).toMatchObject({ on: { mouseup: h1 } });
-  expect(Array.isArray(actual.on.mouseup)).toBe(false);
+  expect(actual).toMatchObject({ onMouseup: h1 });
+  expect(Array.isArray(actual.onMouseup)).toBe(false);
 
   actual = mergeData(
-    { nativeOn: { mouseup: h1 } },
+    { onMouseup: h1 },
     { class: ["btn", "text-center"] }
   );
-  expect(actual).toMatchObject({ nativeOn: { mouseup: h1 } });
-  expect(Array.isArray(actual.nativeOn.mouseup)).toBe(false);
+  expect(actual).toMatchObject({ onMouseup: h1 });
+  expect(Array.isArray(actual.onMouseup)).toBe(false);
 
   actual = mergeData(
-    { on: { mouseup: h1 } },
-    { on: { mouseup: h2 } },
-    { on: { mouseup: h3 } }
+    { onMouseup: h1 },
+    { onMouseup: h2 },
+    { onMouseup: h3 }
   );
-  expect(Array.isArray(actual.on.mouseup)).toBe(true);
-  expect(actual.on.mouseup).toContain(h1);
-  expect(actual.on.mouseup).toContain(h2);
-  expect(actual.on.mouseup).toContain(h3);
+  expect(Array.isArray(actual.onMouseup)).toBe(true);
+  expect(actual.onMouseup).toContain(h1);
+  expect(actual.onMouseup).toContain(h2);
+  expect(actual.onMouseup).toContain(h3);
 });
 
 it("should call the right-most argument first", () => {
@@ -60,18 +56,18 @@ it("should call the right-most argument first", () => {
   };
 
   let actual = mergeData(
-    { on: { click: factory(1) } },
-    { on: { click: factory(2) } },
-    { on: { click: factory(3) } },
-    { on: { click: factory(4) } }
+    { onClick: factory(1) },
+    { onClick: factory(2) },
+    { onClick: factory(3) },
+    { onClick: factory(4) }
   );
 
-  expect(Array.isArray(actual.on.click)).toBe(true);
-  if (!Array.isArray(actual.on.click)) {
+  expect(Array.isArray(actual.onClick)).toBe(true);
+  if (!Array.isArray(actual.onClick)) {
     throw new TypeError();
   }
 
-  for (const fn of actual.on.click) {
+  for (const fn of actual.onClick) {
     fn();
   }
   expect(first).toBe(4);

--- a/__test__/kitchen-sink.test.ts
+++ b/__test__/kitchen-sink.test.ts
@@ -1,4 +1,3 @@
-import { VNodeData } from "vue";
 import { mergeData } from "../src/index";
 
 it("should handle multiple arguments", () => {
@@ -6,65 +5,59 @@ it("should handle multiple arguments", () => {
   function click() {}
   function mouseup() {}
 
-  let expected: VNodeData = {
-    staticClass: "btn ml-auto",
-    class: [{ "text-center": true }, "btn-block", { "btn-primary": true }],
-    on: {
-      click: [click, click],
-      mouseup: [mouseup, mouseup],
-    },
+  let expected: Record<string, unknown> = {
+    class: ["btn", "ml-auto", "btn-block", { "text-center": true, "btn-primary": true }],
+    onClick: [click, click],
+    onMouseup: [mouseup, mouseup],
   };
 
   let actual = mergeData(
-    { staticClass: "ml-auto" },
-    { staticClass: "btn", class: { "btn-primary": true } },
+    { class: "ml-auto" },
+    { class: ["btn", { "btn-primary": true } ] },
     { class: ["btn-block"] },
-    { on: { click, mouseup } },
-    { on: { click, mouseup } },
+    { onClick: click, onMouseup: mouseup },
+    { onClick: click, onMouseup: mouseup },
     { class: { "text-center": true } }
   );
 
-  expect(actual).toEqual(expected);
+  expect(actual.class).toEqual(expect.arrayContaining(expected.class as any[]))
+  expect(actual.onClick).toEqual([click, click]);
+  expect(actual.onMouseup).toEqual([mouseup, mouseup]);
 });
 
 it("should work like in the example", () => {
   let onClick1 = () => alert("💥");
   let onClick2 = () => alert("👍");
 
-  let componentData: VNodeData = {
-    staticClass: "fn-component", // concatenates all static classes
-    class: {
-      active: true,
-      "special-class": false,
-    },
-    attrs: {
-      id: "my-functional-component",
-    },
-    on: {
-      click: onClick1,
-    },
+  let componentData: Record<string, unknown> = {
+    class: [
+      "fn-component",
+      {
+        active: true,
+        "special-class": false,
+      }
+    ],
+    id: "my-functional-component",
+    onClick: onClick1,
   };
+
   // <my-btn variant="primary" type="submit" id="form-submit-btn" @click="onClick">Submit</my-btn>
-  let templateData: VNodeData = {
-    attrs: {
-      id: "form-submit-btn",
-      type: "submit",
-    },
-    on: { click: onClick2 },
+  let templateData: Record<string, unknown> = {
+    id: "form-submit-btn",
+    type: "submit",
+    onClick: onClick2,
   };
 
   expect(mergeData(templateData, componentData)).toEqual({
-    staticClass: "fn-component",
-    class: expect.arrayContaining([
+    class: [
+      "fn-component",
       {
         active: true,
         "special-class": false,
       },
-    ]),
-    attrs: {
-      id: "my-functional-component",
-      type: "submit",
-    },
-    on: { click: expect.arrayContaining([onClick1, onClick2]) },
+    ],
+    id: "my-functional-component",
+    type: "submit",
+    onClick: expect.arrayContaining([onClick1, onClick2]),
   });
 });

--- a/__test__/listener-merge.test.ts
+++ b/__test__/listener-merge.test.ts
@@ -1,0 +1,22 @@
+import { mergeData } from "../src/index";
+
+it("should concatenate event listeners when both source and target listener are an array", () => {
+  function click() {}
+  function mouseup() {}
+
+  const data: Record<string, unknown>[] = [
+    {
+      onClick: [click, mouseup],
+    },
+    {
+      onClick: [mouseup, click],
+    }];
+
+  const expected = {
+    onClick: [mouseup, click, click, mouseup]
+  };
+
+  const actual = mergeData(...data);
+
+  expect(actual).toEqual(expected);
+});

--- a/__test__/nullable-objects.test.ts
+++ b/__test__/nullable-objects.test.ts
@@ -1,12 +1,11 @@
-import { VNodeData } from "vue";
 import { mergeData } from "../src/index";
 
 it("should handle nested nullable objects as initial state", () => {
-  let testData: VNodeData[] = [{ on: undefined }, { staticClass: "foo" }];
-  let actual: VNodeData;
+  let testData: Record<string, unknown>[] = [{ style: undefined}, {class: "foo" }];
+  let actual: Record<string, unknown>;
   let boom = () => (actual = mergeData(...testData));
 
   expect(boom).not.toThrowError();
-  expect(actual.staticClass).toBe("foo");
-  expect(actual.on).toEqual({});
+  expect(actual.class).toBe("foo");
+  expect(actual.style).toEqual([]);
 });

--- a/__test__/reassign.test.ts
+++ b/__test__/reassign.test.ts
@@ -1,12 +1,11 @@
-import { VNodeData } from "vue";
 import { mergeData } from "../src/index";
 
 it("should reassign primitives", () => {
-  let override: VNodeData = { ref: "winning" };
-  let vd1: VNodeData = { ref: "ref1" };
-  let vd2: VNodeData = { ref: "ref2" };
-  let vd3: VNodeData = { ref: "ref3" };
-  let vd4: VNodeData = { ref: "ref4" };
+  let override: Record<string, unknown> = { ref: "winning" };
+  let vd1: Record<string, unknown> = { ref: "ref1" };
+  let vd2: Record<string, unknown> = { ref: "ref2" };
+  let vd3: Record<string, unknown> = { ref: "ref3" };
+  let vd4: Record<string, unknown> = { ref: "ref4" };
 
   let actual = mergeData(vd1, vd2, vd3, vd4, override);
   expect(actual.ref).toBe("winning");

--- a/__test__/string-concat.test.ts
+++ b/__test__/string-concat.test.ts
@@ -1,15 +1,14 @@
-import { VNodeData } from "vue";
 import { mergeData } from "../src/index";
 
 it("should concatenate strings", () => {
-  let test: VNodeData[] = [
-    { staticClass: "" },
-    { staticClass: "class-1" },
-    { staticClass: "class-2" },
-    { staticClass: "" },
-    { staticClass: "class-3" },
+  let test: Record<string, unknown>[] = [
+    { class: "" },
+    { class: "class-1" },
+    { class: "class-2" },
+    { class: "" },
+    { class: "class-3" },
   ];
   let actual = mergeData(...test);
 
-  expect(actual.staticClass).toBe("class-3 class-2 class-1");
+  expect(actual.class).toEqual(expect.arrayContaining(["class-3", "class-2", "class-1"]));
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6239,12 +6239,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "vue": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
-      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
-      "dev": true
-    },
     "w3c-hr-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "fmt": "prettier --config ./.prettierrc --write {__test__,src}/**/*.{ts,js}",
     "rollup": "rollup -c",
-    "prebuild": "scripts/clean.js",
+    "prebuild": "node scripts/clean.js",
     "build": "cross-env NODE_ENV=production npm run rollup",
     "bench": "node benchmark/",
     "size": "cat dist/lib.esm.js | wc -c",
@@ -74,8 +74,6 @@
     "standard-version": "^6.0.1",
     "ts-jest": "^24.0.2",
     "typescript": "^3.5.1",
-    "uglify-es": "^3.3.9",
-    "vue": "^2.6.10"
-  },
-  "dependencies": {}
+    "uglify-es": "^3.3.9"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ function mergeData(): Record<string, unknown> {
       switch (prop) {
         // class merge strategy (parse clas objects, and merge to an array containing strings and max 1 object for conditionals)
         case "class":
-          mergeTarget[prop] = mergeClass(mergeTarget[prop] as AttrsClass, arguments[i][prop] as AttrsClass);
+          mergeTarget[prop] = mergeClass(arguments[i][prop] as AttrsClass, mergeTarget[prop] as AttrsClass);
           continue;
         //merge style by concatenating arrays
         case "style": {
@@ -89,7 +89,6 @@ function mergeData(): Record<string, unknown> {
       }
 
       if (prop.startsWith('on') && prop !== 'on') {
-        debugger;
         // Object, the properties of which to merge via array merge strategy (array concatenation).
         // Callback merge strategy merges callbacks to the beginning of the array,
         // so that the last defined callback will be invoked first.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const pattern = {
 } as const;
 
 function camelReplace(_substr: string, match: string) {
-  return match ? match.toUpperCase() : "";
+  return match.toUpperCase();
 }
 
 function camelCase(str: string) {
@@ -24,9 +24,7 @@ function parseStyle(style: string) {
       continue;
     }
     // May be undefined if the `key: value` pair is incomplete.
-    if (typeof val === "string") {
-      val = val.trim();
-    }
+    val = val.trim();
     styleMap[camelCase(key)] = val;
   }
 

--- a/src/mergeClass.ts
+++ b/src/mergeClass.ts
@@ -1,0 +1,88 @@
+export type AttrsClass =
+  string | string[] | Record<string, boolean> | (string|Record<string, boolean>)[];
+
+function reorganize(attrsClass: AttrsClass): AttrsClass {
+  if (!Array.isArray(attrsClass)) {
+    return attrsClass;
+  }
+
+  const objectIndices: number[] = [];
+  for (let i = 0; i < attrsClass.length; i += 1) {
+    if (typeof attrsClass[i] === 'object') {
+      objectIndices.push(i);
+    }
+  }
+  for (let i = objectIndices.length - 1; i >= 0; i -= 1) {
+    const item = attrsClass[objectIndices[i]] as Record<string, boolean>;
+    attrsClass.splice(objectIndices[i], 1);
+    (attrsClass as Record<string, boolean>[]).push(item);
+  }
+  return attrsClass;
+}
+
+export function mergeClass(
+  attrsClass: AttrsClass | undefined,
+  classes: AttrsClass,
+): AttrsClass {
+  if(classes === '') {
+    return attrsClass;
+  }
+
+  if (attrsClass === undefined) {
+    return classes;
+  }
+
+  if (typeof attrsClass === 'string') {
+    attrsClass = [
+      attrsClass,
+    ] as string[];
+  } else if (!Array.isArray(attrsClass) && typeof attrsClass === 'object') {
+    attrsClass = [
+      attrsClass,
+    ] as (string|Record<string, boolean>)[];
+  }
+
+  if (typeof classes === 'string') {
+    attrsClass.push(classes);
+    return reorganize(attrsClass);
+  }
+
+  if (Array.isArray(classes)) {
+    for (let i = 0; i < classes.length; i += 1) {
+      const item = classes[i];
+      if (typeof item !== 'object') {
+        const attrItem = attrsClass.find((x) => x === item);
+        if (attrItem === undefined) attrsClass.push(item);
+      }
+    }
+  }
+
+  const objectIndex: number = attrsClass.findIndex((x) => typeof x === 'object');
+  let classesRecord: Record<string, boolean> | null = null;
+
+  if (!Array.isArray(classes) && typeof classes === 'object') {
+    if (objectIndex === -1) {
+      (attrsClass as (string|Record<string, boolean>)[]).push(classes);
+      return reorganize(attrsClass);
+    }
+
+    classesRecord = classes;
+  }
+
+  if (classesRecord == null && Array.isArray(classes)) {
+    const classObjectIndex: number = classes.findIndex((x) => typeof x === 'object');
+    if (classObjectIndex >= 0) classesRecord = classes[classObjectIndex] as Record<string, boolean>;
+  }
+
+  if (objectIndex !== -1 && classesRecord != null) {
+    Object.keys(classesRecord).forEach((key) => {
+      if (Array.isArray(attrsClass) && classesRecord != null) {
+        (attrsClass[objectIndex] as Record<string, boolean>)[key] = classesRecord[key];
+      }
+    });
+  } else if (objectIndex === -1 && classesRecord != null) {
+    (attrsClass as Record<string, boolean>[]).push(classesRecord);
+  }
+
+  return reorganize(attrsClass);
+}


### PR DESCRIPTION
This PR converts the code for vue-functional-data-merge to the new Vue 3 format for VNode props ($attrs object in component instances), addressing PRs #18 and #19.

To make this possible, the following changes have been made:

- VNodeData interface is now Record<string, unknown>, as per Vue's internal typing of the $attrs object.
- directives case has been removed (is now a withDirectives wrapper function in vue 3, and no longer part of the vnode binding)
- staticClass case has been removed, as this is now part of the class binding in Vue 3
- introduced a new mergeClass function which can merge class objects in the new vue 3 format
- attrs, props, domProps, scopedSlots, staticStyle, hook, transition, slot, and tag cases have been removed, as these properties are now either obsolete or have been flattened to sit directly under $attrs. only id, key, ref and keepAlive props have been retained to avoid overwriting these.
- nativeOn case has been removed, as in vue 3 the .native modifier no longer exists (events are now native by default when the component does not recognize them)
- a new check has been added outside the switch checking if a property starts with 'on', signifying that it's an event listener. event listeners use the same merge strategy as the 'on' object in Vue 2.
- Updated unit tests to match the new situation in Vue 3.
- removed vue from the package.json dependencies, as vue-functional-data-merge now no longer depends on anything from vue in order to function.

I did _not_ update the version number in package.json, as I feel that it's your authority to decide what the next version number should be.

